### PR TITLE
mergeReq_kgr0831_codeReview & fix

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/Animation/Red Potion.anim
+++ b/Assets/Animation/Red Potion.anim
@@ -81,18 +81,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 1
-    functionName: 
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
-  - time: 1
-    functionName: 
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Animation/small Potions_0.controller
+++ b/Assets/Animation/small Potions_0.controller
@@ -11,7 +11,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 2497986995184528847}
-    m_Position: {x: 200, y: 0, z: 0}
+    m_Position: {x: 280, y: 110, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -182,6 +182,7 @@ MonoBehaviour:
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
   m_RequiresDepthTexture: 0
   m_RequiresColorTexture: 0
+  m_Version: 2
   m_TaaSettings:
     m_Quality: 3
     m_FrameInfluence: 0.1
@@ -189,7 +190,6 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
-  m_Version: 2
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -316,8 +316,6 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
-  m_ForceMeshLod: -1
-  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -339,7 +337,6 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0

--- a/Assets/Scripts/Node.cs
+++ b/Assets/Scripts/Node.cs
@@ -3,13 +3,41 @@ using UnityEngine;
 public class Node : MonoBehaviour
 {
     public bool isUsable; //공간을 물약으로 채울 수 있는지 여부를 결정합니다.
-    
-    public GameObject potion; //Node가 현제 가지고 있는 포션 오브젝트
+
+    public GameObject potion; //Node가 현재 가지고 있는 포션 오브젝트
 
     //생성자
-    public Node(bool isUsable, GameObject potion)
+    // public Node(bool isUsable, GameObject potion)
+    // {
+    //     this.isUsable = isUsable;
+    //     this.potion = potion;
+    // }
+
+    // 추가: 셀 좌표
+    public int x;
+    public int y;
+
+    public bool isEmpty => potion == null; // 변수명은 어디까지나 소문자로 시작할 것 아니면 걍 함수로 바꾸셈
+    // public bool IsEmpty() => potion == null;
+    
+    // 칸 초기화(생성자 대신 사용)
+    public void Initialize(int kX, int kY, bool kUsable = true) // 파라미터 이름 바꿔놈 앞에 접두사 붙여서 구분하셈 this 보다는
     {
-        this.isUsable = isUsable;
-        this.potion = potion;
+        x = kX;
+        y = kY;
+        isUsable = kUsable;
     }
+
+    // 칸에 포션 배치 + 좌표 동기화
+    public void SetPotion(GameObject go)
+    {
+        potion = go;
+        var p = go != null ? go.GetComponent<Potion>() : null;
+        if (p != null)
+        {
+            p.SetIndices(x, y); // 기존 SetIndicies 호출 보완
+        }
+    }
+
+    public void Clear() => potion = null;
 }

--- a/Assets/Scripts/Potion.cs
+++ b/Assets/Scripts/Potion.cs
@@ -13,7 +13,7 @@ PotionBoard는 게임 오브젝트로서 여러 Node들을 포함하고 있습�
 public class Potion : MonoBehaviour
 {
     public PotionType potionType;
-    
+
     public int xIndex; // 포션의 x 좌표
     public int yIndex; // 포션의 y 좌표
 
@@ -29,8 +29,8 @@ public class Potion : MonoBehaviour
         xIndex = x;
         yIndex = y;
     }
-    
-    public void SetIndicies(int x, int y)
+
+    public void SetIndices(int x, int y)
     {
         xIndex = x;
         yIndex = y;

--- a/Assets/Scripts/PotionBoard.cs
+++ b/Assets/Scripts/PotionBoard.cs
@@ -8,25 +8,29 @@ public class PotionBoard : MonoBehaviour
     public int height = 8;//보드의 세로 크기
 
     //노드간의 간격 설정
-    public float spacingX;//노드간의 가로 간격
-    public float spacingY;//노드간의 세로 간격
-    
+    public float spacingX; //노드간의 가로 간격
+    public float spacingY; //노드간의 세로 간격
+
     public GameObject[] potionPrefab; //포션 프리팹 배열
-    
+
     //포션 보드의 2차원 배열 선언
     private Node[,] _potionBoard; // 포션 보드의 2차원 배열
-    //2차원 배열이란? 2개의 인덱스를 사용하여 데이터를 저장하는 배열입니다. 예를 들어 아파트 생각하면 편합니다.
-    //각 층과 호수를 사용하여 특정 아파트를 지정할 수 있죠. 각 층은 첫 번째 인덱스, 각 호수는 두 번째 인덱스로 생각할 수 있습니다.
-    
-    public GameObject potionBoardGo; //포션 보드 게임 오브젝트
-    
-    //"일단 강의에서 이렇게 만들라 해서 만들긴 하는데 이거 싱글톤 나중에 안쓸거같음"
-    public static PotionBoard Instance; //싱글톤 인스턴스 
-    //싱글톤이란? 싱글톤 패턴은 클래스의 인스턴스가 오직 하나만 존재하도록 보장하는 디자인 패턴입니다.
-    //이를 통해 전역적으로 접근 가능한 단일 인스턴스를 제공할 수 있습니다. 보통 Instance라는 정적 변수를 사용하여 구현합니다. "우리 텍스트 RPG만들때 게임메니져 이걸로 만듬"
+                                  // 2차원 배열이란? 2개의 인덱스를 사용하여 데이터를 저장하는 배열입니다. 예를 들어 아파트 생각하면 편합니다.
+                                  // 각 층과 호수를 사용하여 특정 아파트를 지정할 수 있죠. 각 층은 첫 번째 인덱스, 각 호수는 두 번째 인덱스로 생각할 수 있습니다.
+
+    public GameObject potionBoardGo; // 포션 보드 게임 오브젝트
+
+    // "일단 강의에서 이렇게 만들라 해서 만들긴 하는데 이거 싱글톤 나중에 안쓸거같음
+    public static PotionBoard Instance; // 싱글톤 인스턴스 
+    // 싱글톤이란? 싱글톤 패턴은 클래스의 인스턴스가 오직 하나만 존재하도록 보장하는 디자인 패턴입니다.
+    // 이를 통해 전역적으로 접근 가능한 단일 인스턴스를 제공할 수 있습니다. 보통 Instance라는 정적 변수를 사용하여 구현합니다. "우리 텍스트 RPG만들때 게임메니져 이걸로 만듬"
+
+    [Header("Optional Parents")]
+    public Transform potionsRoot; // 포션 전용 부모(선택)
 
     private void Awake()
     {
+        // 이를 통해 전역적으로 접근 가능한 단일 인스턴스를 제공할 수 있습니다. 보통 Instance라는 정적 변수를 사용하여 구현합니다. "우리 텍스트 RPG만들때 게임메니져 이걸로 만듬"
         Instance = this;
     }
 
@@ -37,12 +41,12 @@ public class PotionBoard : MonoBehaviour
 
     void InitializeBoard()
     {
-        _potionBoard = new Node[width, height]; //포션 보드 배열 초기화 "대충 안에 있는 노드들 다 지운다는거"
-        
-        spacingX = (float)(width - 1) / 2; //가로 간격 설정
-        spacingY = (float)(height - 1) / 2; //세로 간격 설정
-        
-        //포션 랜덤 생성 후 보드에 채우기
+        _potionBoard = new Node[width, height]; // 포션 보드 배열 초기화 "대충 안에 있는 노드들 다 지운다는거"
+
+        spacingX = (float)(width - 1) / 2; // 가로 간격 설정
+        spacingY = (float)(height - 1) / 2; // 세로 간격 설정
+
+        // 포션 랜덤 생성 후 보드에 채우기
         for (int y = 0; y < height; y++)
         {
             for (int x = 0; x < width; x++)
@@ -50,13 +54,34 @@ public class PotionBoard : MonoBehaviour
                 Vector2 position = new Vector2(x - spacingX, y - spacingY); //포션의 위치 계산
 
                 int randomIndex = Random.Range(0, potionPrefab.Length); //랜덤한 포션 프리팹 인덱스 선택
-                
-                GameObject potion = Instantiate(potionPrefab[randomIndex], position, Quaternion.identity);// 포션 인스턴스 생성
-                potion.GetComponent<Potion>().SetIndicies(x, y); //포션의 좌표 설정
-                
-                _potionBoard[x, y] = potion.AddComponent<Node>(); //노드 생성 및 포션 보드에 할당
+
+                // 포션 인스턴스 생성
+                Transform parentForPotion = potionsRoot != null ? potionsRoot :
+                                            (potionBoardGo != null ? potionBoardGo.transform : transform);
+                GameObject potion = Instantiate(
+                    potionPrefab[randomIndex],
+                    position,
+                    Quaternion.identity,
+                    parentForPotion
+                );// 포션 인스턴스 생성
+
+                // (원본 호출 보완) 좌표 설정 메서드 철자 보정
+                var pComp = potion.GetComponent<Potion>();
+                if (pComp != null) pComp.SetIndices(x, y); //포션의 좌표 설정
+
+                // 노드 생성 및 포션 보드에 할당
+                // (기존) _potionBoard[x, y] = potion.AddComponent<Node>(); //노드 생성 및 포션 보드에 할당
+                // → 노드는 '칸' GameObject로 분리해 영속 유지
+                GameObject nodeGO = new GameObject($"Node_{x}_{y}");
+                nodeGO.transform.SetParent(potionBoardGo != null ? potionBoardGo.transform : transform, false);
+                nodeGO.transform.localPosition = position;
+
+                Node node = nodeGO.AddComponent<Node>();
+                node.Initialize(x, y, true);
+                node.SetPotion(potion);
+
+                _potionBoard[x, y] = node; //포션 보드에 노드 할당
             }
         }
-        
     }
 }

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -87,6 +87,8 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
+    - rid: -2
+      type: {class: , ns: , asm: }
     - rid: 2017667646741282816
       type: {class: PostProcessData/ShaderResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
@@ -242,6 +244,9 @@ MonoBehaviour:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
         m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
         m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
+        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
+        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
+        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
@@ -275,8 +280,6 @@ MonoBehaviour:
         m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
-        m_ClusterDeferred: {fileID: 4800000, guid: 222cce62363a44a380c36bf03b392608, type: 3}
-        m_StencilDitherMaskSeedPS: {fileID: 4800000, guid: 8c3ee818f2efa514c889881ccb2e95a2, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
     - rid: 7752762179098771464
       type: {class: UniversalRenderPipelineRuntimeXRResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,13 +1,8 @@
 {
   "dependencies": {
-    "com.unity.2d.animation": "12.0.2",
-    "com.unity.2d.aseprite": "2.0.2",
-    "com.unity.2d.psdimporter": "11.0.1",
     "com.unity.2d.sprite": "1.0.0",
-    "com.unity.2d.spriteshape": "12.0.1",
     "com.unity.2d.tilemap": "1.0.0",
-    "com.unity.2d.tilemap.extras": "5.0.1",
-    "com.unity.collab-proxy": "2.10.0",
+    "com.unity.feature.2d": "2.0.1",
     "com.unity.ide.rider": "3.0.38",
     "com.unity.ide.visualstudio": "2.0.25",
     "com.unity.inputsystem": "1.14.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.unity.2d.animation": {
-      "version": "12.0.2",
-      "depth": 0,
+      "version": "10.2.1",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "11.0.1",
+        "com.unity.2d.common": "9.1.1",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.collections": "1.2.4",
         "com.unity.modules.animation": "1.0.0",
@@ -14,39 +14,44 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.aseprite": {
-      "version": "2.0.2",
-      "depth": 0,
+      "version": "1.1.10",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
+        "com.unity.2d.common": "6.0.6",
         "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.tilemap": "1.0.0",
-        "com.unity.2d.common": "11.0.1",
         "com.unity.mathematics": "1.2.6",
         "com.unity.modules.animation": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
     "com.unity.2d.common": {
-      "version": "11.0.1",
-      "depth": 1,
+      "version": "9.1.1",
+      "depth": 2,
       "source": "registry",
       "dependencies": {
+        "com.unity.burst": "1.8.4",
         "com.unity.2d.sprite": "1.0.0",
         "com.unity.mathematics": "1.1.0",
-        "com.unity.modules.uielements": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.burst": "1.8.4"
+        "com.unity.modules.uielements": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.2d.pixel-perfect": {
+      "version": "5.0.3",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.2d.psdimporter": {
-      "version": "11.0.1",
-      "depth": 0,
+      "version": "9.1.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.2d.common": "11.0.1",
-        "com.unity.2d.sprite": "1.0.0",
-        "com.unity.2d.tilemap": "1.0.0"
+        "com.unity.2d.common": "9.1.1",
+        "com.unity.2d.sprite": "1.0.0"
       },
       "url": "https://packages.unity.com"
     },
@@ -57,12 +62,12 @@
       "dependencies": {}
     },
     "com.unity.2d.spriteshape": {
-      "version": "12.0.1",
-      "depth": 0,
+      "version": "10.0.7",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
+        "com.unity.2d.common": "9.0.7",
         "com.unity.mathematics": "1.1.0",
-        "com.unity.2d.common": "11.0.1",
         "com.unity.modules.physics2d": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -77,12 +82,12 @@
       }
     },
     "com.unity.2d.tilemap.extras": {
-      "version": "5.0.1",
-      "depth": 0,
+      "version": "4.1.0",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.tilemap": "1.0.0",
         "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.modules.tilemap": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
@@ -97,16 +102,9 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.collab-proxy": {
-      "version": "2.10.0",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.collections": {
       "version": "2.6.2",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {
         "com.unity.burst": "1.8.23",
@@ -122,6 +120,21 @@
       "depth": 1,
       "source": "builtin",
       "dependencies": {}
+    },
+    "com.unity.feature.2d": {
+      "version": "2.0.1",
+      "depth": 0,
+      "source": "builtin",
+      "dependencies": {
+        "com.unity.2d.animation": "10.2.1",
+        "com.unity.2d.pixel-perfect": "5.0.3",
+        "com.unity.2d.psdimporter": "9.1.0",
+        "com.unity.2d.sprite": "1.0.0",
+        "com.unity.2d.spriteshape": "10.0.7",
+        "com.unity.2d.tilemap": "1.0.0",
+        "com.unity.2d.tilemap.extras": "4.1.0",
+        "com.unity.2d.aseprite": "1.1.10"
+      }
     },
     "com.unity.ide.rider": {
       "version": "3.0.38",
@@ -152,7 +165,7 @@
     },
     "com.unity.mathematics": {
       "version": "1.3.2",
-      "depth": 1,
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -167,17 +180,17 @@
     },
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.5",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "17.2.0",
+      "version": "17.0.4",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.burst": "1.8.14",
+        "com.unity.burst": "1.8.20",
         "com.unity.mathematics": "1.3.2",
         "com.unity.ugui": "2.0.0",
         "com.unity.collections": "2.4.3",
@@ -188,12 +201,12 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "17.2.0",
+      "version": "17.0.4",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.2.0",
-        "com.unity.shadergraph": "17.2.0",
+        "com.unity.render-pipelines.core": "17.0.4",
+        "com.unity.shadergraph": "17.0.4",
         "com.unity.render-pipelines.universal-config": "17.0.3"
       }
     },
@@ -223,11 +236,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "17.2.0",
+      "version": "17.0.4",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.2.0",
+        "com.unity.render-pipelines.core": "17.0.4",
         "com.unity.searcher": "4.9.3"
       }
     },
@@ -243,7 +256,7 @@
     },
     "com.unity.test-framework.performance": {
       "version": "3.2.0",
-      "depth": 2,
+      "depth": 3,
       "source": "registry",
       "dependencies": {
         "com.unity.test-framework": "1.1.33",
@@ -430,8 +443,7 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0",
-        "com.unity.modules.hierarchycore": "1.0.0",
-        "com.unity.modules.physics": "1.0.0"
+        "com.unity.modules.hierarchycore": "1.0.0"
       }
     },
     "com.unity.modules.umbra": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.2.10f1
-m_EditorVersionWithRevision: 6000.2.10f1 (d3d30d158480)
+m_EditorVersion: 6000.0.60f1
+m_EditorVersionWithRevision: 6000.0.60f1 (61dfb374e36f)


### PR DESCRIPTION
1. UI를 pixel 그래픽으로 통일
2. Node는 셀 컴포넌트로 분리해야 함. 지금처럼 포션 오브젝트에 
AddComponent하는 구조는 지양
3. MonoBehaviour에 생성자 쓰지 말 것. Unity가 호출 안 함
4. spacingX/Y는 이름 불일치. 실제론 중앙 오프셋이므로 originX/Y로 변경하고, 셀 간격은 cellSizeX/Y로 분리
5. 생성한 오브젝트는 부모 트랜스폼 지정해서 계층 정리할 것
6. Node 상태 세팅 누락됨. 생성 직후 node.Set 등으로 현재 포션 참조 연결 필요.
7. 프리팹 배열 가드 필요. potionPrefab 비었을 때 에러 처리
8. SetIndicies → SetIndices 오타임 이거
9. 싱글톤 가드 추가. 중복 인스턴스 발생 시 제거 또는 DontDestroyOnLoad 패턴 정리.
10. 직렬화 접근 제어 정리. 외부에서 바꾸지 않는 값은 private + [SerializeField]로 관리
11. 보드/포션 루트 Transform 분리하면 런타임 정리 쉬움
12. 입력은 Update, 물리 이동은 FixedUpdate로 분리한 건 굿
13. 코드 스타일 통일할 것 private어떤건 생략하고 어떤건 안함. 변수 명 또한 _가 어떤건 달리고 어떤건 안달림
14. 기타 사항들은 코드에 주석 달아놈