### PR TITLE
Use 2D overlap for piece selection

### DIFF
--- a/Assets/Scripts/BoardSystem.cs
+++ b/Assets/Scripts/BoardSystem.cs
@@ -90,16 +90,16 @@ public class BoardSystem : MonoBehaviour
             // 1. 마우스 스크린 좌표 읽기
             Vector2 mousePos = Mouse.current.position.ReadValue();
 
-            // 2. 스크린 좌표 → Ray
-            Ray ray = mainCam.ScreenPointToRay(mousePos);
+            // 2. 스크린 좌표 → 월드 좌표 (2D 전용)
+            Vector3 worldPos = mainCam.ScreenToWorldPoint(new Vector3(mousePos.x, mousePos.y, 0f));
 
-            // 3. 2D Raycast
-            RaycastHit2D hit = Physics2D.Raycast(ray.origin, ray.direction);
+            // 3. 해당 지점을 덮는 2D 콜라이더 찾기
+            Collider2D collider = Physics2D.OverlapPoint(worldPos);
 
             // 4. 맞은 콜라이더가 있고, 거기에 Piece가 붙어 있는지 확인
-            if (hit.collider != null)
+            if (collider != null)
             {
-                Piece piece = hit.collider.gameObject.GetComponent<Piece>();
+                Piece piece = collider.gameObject.GetComponent<Piece>();
                 if (piece != null)
                 {
                     if (isProcessingMoving)


### PR DESCRIPTION
## Summary
- switch the board input logic to convert the mouse click into a 2D world point
- use `Physics2D.OverlapPoint` and fetch the hit `Piece` so clicks reliably resolve in 2D

## Testing
- Not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ac33a539c833083416fabb3202c73)