### PR TITLE
Refine swap match validation

### DIFF
--- a/Assets/Scripts/BoardSystem.cs
+++ b/Assets/Scripts/BoardSystem.cs
@@ -454,16 +454,30 @@ public class BoardSystem : MonoBehaviour
     {
         yield return new WaitForSeconds(0.2f);
 
-        bool hasMatched = CheckBoardToMatches();
-        
-        Debug.Log($"현제 매치 상태 = {hasMatched}");
+        bool hasMatchOnCurrent = HasMatchAt(currentPiece);
+        bool hasMatchOnTarget = HasMatchAt(targetPiece);
 
-        if (!hasMatched)
+        Debug.Log($"현제 매치 상태 = {hasMatchOnCurrent || hasMatchOnTarget}");
+
+        if (!hasMatchOnCurrent && !hasMatchOnTarget)
         {
             DoSwap(currentPiece, targetPiece);
         }
-        
+
         isProcessingMoving = false;
+    }
+
+    private bool HasMatchAt(Piece piece)
+    {
+        if (piece == null)
+        {
+            return false;
+        }
+
+        ResetMatchedFlags();
+        MatchResult matchResult = IsConnected(piece);
+
+        return matchResult.connectedPieces != null && matchResult.connectedPieces.Count >= 3;
     }
     
     /// <summary>


### PR DESCRIPTION
## Summary
- add a HasMatchAt helper that resets match flags and checks whether a specific piece forms a match
- update the swap resolution coroutine to validate matches only on the swapped pieces and roll back swaps when neither piece matches

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b12514a6c8330bd67e846e49cb205)