### PR TITLE
Refactor board system to match potion board logic

### DIFF
--- a/Assets/Scripts/ArrayLayout.cs
+++ b/Assets/Scripts/ArrayLayout.cs
@@ -1,0 +1,25 @@
+using System;
+
+[Serializable]
+public class ArrayLayout
+{
+    public Row[] rows;
+
+    public bool IsBlocked(int x, int y)
+    {
+        if (rows == null || y < 0 || y >= rows.Length)
+            return false;
+
+        Row row = rows[y];
+        if (row?.row == null || x < 0 || x >= row.row.Length)
+            return false;
+
+        return row.row[x];
+    }
+}
+
+[Serializable]
+public class Row
+{
+    public bool[] row;
+}

--- a/Assets/Scripts/Node.cs
+++ b/Assets/Scripts/Node.cs
@@ -1,41 +1,40 @@
 using UnityEngine;
 
-public class Node : MonoBehaviour
+[System.Serializable]
+public class Node
 {
-    public bool isUsable; // 공간을 피스로 채울 수 있는지 여부를 결정합니다.
+    public bool isUsable;
+    public GameObject piece;
 
-    public GameObject piece; // Node가 현재 가지고 있는 피스 오브젝트
-
-    //생성자
-    // public Node(bool isUsable, GameObject piece)
-    // {
-    //     this.isUsable = isUsable;
-    //     this.piece = piece;
-    // }
-
-    // 추가: 셀 좌표
     public int x;
     public int y;
 
-    public bool IsEmpty => piece == null; // 변수명은 어디까지나 소문자로 시작할 것 아니면 걍 함수로 바꾸셈
-    // public bool IsEmpty() => piece == null;
-    
-    // 칸 초기화(생성자 대신 사용)
-    public void Initialize(int kX, int kY, bool kUsable = true) // 파라미터 이름 바꿔놈 앞에 접두사 붙여서 구분하셈 this 보다는
+    public bool IsEmpty => piece == null;
+
+    public Node()
+    {
+    }
+
+    public Node(bool usable, GameObject attachedPiece)
+    {
+        isUsable = usable;
+        piece = attachedPiece;
+    }
+
+    public void Initialize(int kX, int kY, bool kUsable = true)
     {
         x = kX;
         y = kY;
         isUsable = kUsable;
     }
 
-    // 칸에 피스 배치 + 좌표 동기화
     public void SetPiece(GameObject go)
     {
         piece = go;
         var p = go != null ? go.GetComponent<Piece>() : null;
         if (p != null)
         {
-            p.SetIndices(x, y); // 기존 SetIndices 호출 보완
+            p.SetIndices(x, y);
         }
     }
 


### PR DESCRIPTION
## Summary
- Reworked the piece board to mirror the provided potion board flow while keeping the existing input handling
- Simplified nodes into serializable data containers and added an ArrayLayout helper for blocked cells
- Updated match processing to cascade removals and refills following the new logic

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fac8fa4b48330a17da16939881a04)